### PR TITLE
Fix Bugs

### DIFF
--- a/.stylua.toml
+++ b/.stylua.toml
@@ -1,0 +1,10 @@
+column_width = 120
+line_endings = "Unix"
+indent_type = "Spaces"
+indent_width = 4
+quote_style = "AutoPreferDouble"
+call_parentheses = "Always"
+collapse_simple_statement = "Never"
+
+[sort_requires]
+enabled = false

--- a/lua/pomodoro.lua
+++ b/lua/pomodoro.lua
@@ -44,11 +44,11 @@ local function calc_time_remaining(duration, start)
 end
 
 function Pomodoro:time_break()
-  if self.timers_completed == 0 then
-    return self.opts.time_break_long
-  else
-    return self.opts.time_break_short
-  end
+	if self.timers_completed == self.opts.timers_to_long_break then
+		return self.opts.time_break_long
+	else
+		return self.opts.time_break_short
+	end
 end
 
 function Pomodoro:start_pomodoro()

--- a/lua/pomodoro.lua
+++ b/lua/pomodoro.lua
@@ -35,12 +35,12 @@ local uv = vim.uv or vim.loop
 ---@param start integer
 ---@return string|osdate
 local function calc_time_remaining(duration, start)
-  local seconds = duration * 60 - os.difftime(os.time(), start)
-  if math.floor(seconds / 60) >= 60 then
-    return os.date('!%0H:%0M:%0S', seconds)
-  else
-    return os.date('!%0M:%0S', seconds)
-  end
+	local seconds = duration * 60 - os.difftime(os.time(), start)
+	if math.floor(seconds / 60) >= 60 then
+		return os.date("!%H:%M:%S", seconds)
+	else
+		return os.date("!%M:%S", seconds)
+	end
 end
 
 function Pomodoro:time_break()

--- a/lua/pomodoro.lua
+++ b/lua/pomodoro.lua
@@ -20,13 +20,13 @@ local ui = require("pomodoro.ui")
 ---@field status fun()
 ---@field setup fun(pomodoroOpts)
 local Pomodoro = {
-	opts = config,
-	ui = ui,
-	state = "stopped",
-	timer = nil,
-	timers_completed = 0,
-	work_started_at = 0,
-	break_started_at = 0,
+    opts = config,
+    ui = ui,
+    state = "stopped",
+    timer = nil,
+    timers_completed = 0,
+    work_started_at = 0,
+    break_started_at = 0,
 }
 
 local uv = vim.uv or vim.loop
@@ -35,109 +35,109 @@ local uv = vim.uv or vim.loop
 ---@param start integer
 ---@return string|osdate
 local function calc_time_remaining(duration, start)
-	local seconds = duration * 60 - os.difftime(os.time(), start)
-	if math.floor(seconds / 60) >= 60 then
-		return os.date("!%H:%M:%S", seconds)
-	else
-		return os.date("!%M:%S", seconds)
-	end
+    local seconds = duration * 60 - os.difftime(os.time(), start)
+    if math.floor(seconds / 60) >= 60 then
+        return os.date("!%H:%M:%S", seconds)
+    else
+        return os.date("!%M:%S", seconds)
+    end
 end
 
 function Pomodoro:time_break()
-	if self.timers_completed == self.opts.timers_to_long_break then
-		return self.opts.time_break_long
-	else
-		return self.opts.time_break_short
-	end
+    if self.timers_completed == self.opts.timers_to_long_break then
+        return self.opts.time_break_long
+    else
+        return self.opts.time_break_short
+    end
 end
 
 function Pomodoro:start_pomodoro()
-	if self.state ~= "started" then
-		local work_milliseconds = self.opts.time_work * 60 * 1000
-		self.timer:start(
-			work_milliseconds,
-			0,
-			vim.schedule_wrap(function()
-				self.ui.pomodoro_completed_menu(self)
-			end)
-		)
-		self.work_started_at = os.time()
-		self.state = "started"
-	end
+    if self.state ~= "started" then
+        local work_milliseconds = self.opts.time_work * 60 * 1000
+        self.timer:start(
+            work_milliseconds,
+            0,
+            vim.schedule_wrap(function()
+                self.ui.pomodoro_completed_menu(self)
+            end)
+        )
+        self.work_started_at = os.time()
+        self.state = "started"
+    end
 end
 
 function Pomodoro:start_break()
-	if self.state == "started" then
-		self.timers_completed = (self.timers_completed + 1) % self.opts.timers_to_long_break
-		local break_milliseconds = self:time_break() * 60 * 1000
-		self.timer:start(
-			break_milliseconds,
-			0,
-			vim.schedule_wrap(function()
-				self.ui.break_completed_menu(self)
-			end)
-		)
-		self.break_started_at = os.time()
-		self.state = "break"
-	end
+    if self.state == "started" then
+        self.timers_completed = (self.timers_completed + 1) % self.opts.timers_to_long_break
+        local break_milliseconds = self:time_break() * 60 * 1000
+        self.timer:start(
+            break_milliseconds,
+            0,
+            vim.schedule_wrap(function()
+                self.ui.break_completed_menu(self)
+            end)
+        )
+        self.break_started_at = os.time()
+        self.state = "break"
+    end
 end
 
 function Pomodoro:start_()
-	if self.state == "stopped" then
-		self.timer = uv.new_timer()
-		self:start_pomodoro()
-	end
+    if self.state == "stopped" then
+        self.timer = uv.new_timer()
+        self:start_pomodoro()
+    end
 end
 
 function Pomodoro:statusline_()
-	if self.state == "stopped" then
-		return self.opts.icons.stopped .. " (inactive)"
-	elseif self.state == "started" then
-		return self.opts.icons.started .. " " .. calc_time_remaining(self.opts.time_work, self.work_started_at)
-	else
-		local break_minutes = self:time_break()
-		return self.opts.icons.breaking .. " " .. calc_time_remaining(break_minutes, self.break_started_at)
-	end
+    if self.state == "stopped" then
+        return self.opts.icons.stopped .. " (inactive)"
+    elseif self.state == "started" then
+        return self.opts.icons.started .. " " .. calc_time_remaining(self.opts.time_work, self.work_started_at)
+    else
+        local break_minutes = self:time_break()
+        return self.opts.icons.breaking .. " " .. calc_time_remaining(break_minutes, self.break_started_at)
+    end
 end
 
 function Pomodoro:stop_()
-	if self.state ~= "stopped" then
-		self.timer:stop()
-		self.timer:close()
-		self.state = "stopped"
-	end
+    if self.state ~= "stopped" then
+        self.timer:stop()
+        self.timer:close()
+        self.state = "stopped"
+    end
 end
 
 Pomodoro.start = function()
-	Pomodoro.start_(Pomodoro)
+    Pomodoro.start_(Pomodoro)
 end
 Pomodoro.stop = function()
-	Pomodoro.stop_(Pomodoro)
+    Pomodoro.stop_(Pomodoro)
 end
 Pomodoro.statusline = function()
-	return Pomodoro.statusline_(Pomodoro)
+    return Pomodoro.statusline_(Pomodoro)
 end
 Pomodoro.status = function()
-	vim.notify(Pomodoro.statusline(), vim.log.levels.INFO, { title = "pomodoro.nvim" })
+    vim.notify(Pomodoro.statusline(), vim.log.levels.INFO, { title = "pomodoro.nvim" })
 end
 
 local function setup_commands()
-	local command_opts = { bang = false, bar = false, complete = nil }
-	vim.api.nvim_create_user_command("PomodoroStart", function()
-		Pomodoro:start()
-	end, command_opts)
-	vim.api.nvim_create_user_command("PomodoroStatus", function()
-		Pomodoro:status()
-	end, command_opts)
-	vim.api.nvim_create_user_command("PomodoroStop", function()
-		Pomodoro:stop()
-	end, command_opts)
+    local command_opts = { bang = false, bar = false, complete = nil }
+    vim.api.nvim_create_user_command("PomodoroStart", function()
+        Pomodoro:start()
+    end, command_opts)
+    vim.api.nvim_create_user_command("PomodoroStatus", function()
+        Pomodoro:status()
+    end, command_opts)
+    vim.api.nvim_create_user_command("PomodoroStop", function()
+        Pomodoro:stop()
+    end, command_opts)
 end
 
 function Pomodoro.setup(opts)
-	opts = opts or {}
-	Pomodoro.opts = vim.tbl_deep_extend("force", Pomodoro.opts, opts)
-	setup_commands()
+    opts = opts or {}
+    Pomodoro.opts = vim.tbl_deep_extend("force", Pomodoro.opts, opts)
+    setup_commands()
 end
 
 return Pomodoro

--- a/lua/pomodoro.lua
+++ b/lua/pomodoro.lua
@@ -2,15 +2,15 @@ local config = require("pomodoro.config")
 local ui = require("pomodoro.ui")
 
 ---@class Pomodoro
----@field private opts pomodoroOpts
+---@field opts pomodoroOpts
 ---@field private state "stopped" | "started" | "break"
 ---@field private timer uv_timer_t?
 ---@field private timers_completed integer
 ---@field private work_started_at integer
 ---@field private break_started_at integer
 ---@field private time_break fun(self: Pomodoro):integer
----@field private start_pomodoro fun(self: Pomodoro)
----@field private start_break fun(self: Pomodoro)
+---@field start_pomodoro fun(self: Pomodoro)
+---@field start_break fun(self: Pomodoro)
 ---@field private statusline_ fun(self: Pomodoro):string
 ---@field private start_ fun(self: Pomodoro)
 ---@field private stop_ fun(self: Pomodoro)

--- a/lua/pomodoro.lua
+++ b/lua/pomodoro.lua
@@ -20,13 +20,13 @@ local ui = require("pomodoro.ui")
 ---@field status fun()
 ---@field setup fun(pomodoroOpts)
 local Pomodoro = {
-  opts = config,
-  ui = ui,
-  state = "stopped",
-  timer = nil,
-  timers_completed = 0,
-  work_started_at = 0,
-  break_started_at = 0,
+	opts = config,
+	ui = ui,
+	state = "stopped",
+	timer = nil,
+	timers_completed = 0,
+	work_started_at = 0,
+	break_started_at = 0,
 }
 
 local uv = vim.uv or vim.loop
@@ -52,66 +52,92 @@ function Pomodoro:time_break()
 end
 
 function Pomodoro:start_pomodoro()
-  if self.state ~= "started" then
-    local work_milliseconds = self.opts.time_work * 60 * 1000
-    self.timer:start(work_milliseconds, 0, vim.schedule_wrap(function() self.ui.pomodoro_completed_menu(self.opts.ui) end))
-    self.work_started_at = os.time()
-    self.state = "started"
-  end
+	if self.state ~= "started" then
+		local work_milliseconds = self.opts.time_work * 60 * 1000
+		self.timer:start(
+			work_milliseconds,
+			0,
+			vim.schedule_wrap(function()
+				self.ui.pomodoro_completed_menu(self)
+			end)
+		)
+		self.work_started_at = os.time()
+		self.state = "started"
+	end
 end
 
 function Pomodoro:start_break()
-  if self.state == "started" then
-    self.timers_completed = (self.timers_completed + 1) % self.opts.timers_to_long_break
-    local break_milliseconds = self:time_break() * 60 * 1000
-    self.timer:start(break_milliseconds, 0, vim.schedule_wrap(function() self.ui.break_completed_menu(self.opts.ui) end))
-    self.break_started_at = os.time()
-    self.state = "break"
-  end
+	if self.state == "started" then
+		self.timers_completed = (self.timers_completed + 1) % self.opts.timers_to_long_break
+		local break_milliseconds = self:time_break() * 60 * 1000
+		self.timer:start(
+			break_milliseconds,
+			0,
+			vim.schedule_wrap(function()
+				self.ui.break_completed_menu(self)
+			end)
+		)
+		self.break_started_at = os.time()
+		self.state = "break"
+	end
 end
 
 function Pomodoro:start_()
-  if self.state == "stopped" then
-    self.timer = uv.new_timer()
-    self:start_pomodoro()
-  end
+	if self.state == "stopped" then
+		self.timer = uv.new_timer()
+		self:start_pomodoro()
+	end
 end
 
 function Pomodoro:statusline_()
-  if self.state == "stopped" then
-    return self.opts.icons.stopped .. " (inactive)"
-  elseif self.state == "started" then
-    return self.opts.icons.started .. " " .. calc_time_remaining(self.opts.time_work, self.work_started_at)
-  else
-    local break_minutes = self:time_break()
-    return self.opts.icons.breaking  .. " " .. calc_time_remaining(break_minutes, self.break_started_at)
-  end
+	if self.state == "stopped" then
+		return self.opts.icons.stopped .. " (inactive)"
+	elseif self.state == "started" then
+		return self.opts.icons.started .. " " .. calc_time_remaining(self.opts.time_work, self.work_started_at)
+	else
+		local break_minutes = self:time_break()
+		return self.opts.icons.breaking .. " " .. calc_time_remaining(break_minutes, self.break_started_at)
+	end
 end
 
 function Pomodoro:stop_()
-  if self.state ~= "stopped" then
-    self.timer:stop()
-    self.timer:close()
-    self.state = "stopped"
-  end
+	if self.state ~= "stopped" then
+		self.timer:stop()
+		self.timer:close()
+		self.state = "stopped"
+	end
 end
 
-Pomodoro.start = function () Pomodoro.start_(Pomodoro) end
-Pomodoro.stop = function () Pomodoro.stop_(Pomodoro) end
-Pomodoro.statusline = function () return Pomodoro.statusline_(Pomodoro) end
-Pomodoro.status = function() vim.notify(Pomodoro.statusline(), vim.log.levels.INFO, {title = "pomodoro.nvim"}) end
+Pomodoro.start = function()
+	Pomodoro.start_(Pomodoro)
+end
+Pomodoro.stop = function()
+	Pomodoro.stop_(Pomodoro)
+end
+Pomodoro.statusline = function()
+	return Pomodoro.statusline_(Pomodoro)
+end
+Pomodoro.status = function()
+	vim.notify(Pomodoro.statusline(), vim.log.levels.INFO, { title = "pomodoro.nvim" })
+end
 
 local function setup_commands()
-  local command_opts = {bang = false, bar = false, complete = nil}
-  vim.api.nvim_create_user_command("PomodoroStart", function() Pomodoro:start() end, command_opts)
-  vim.api.nvim_create_user_command("PomodoroStatus", function() Pomodoro:status() end, command_opts)
-  vim.api.nvim_create_user_command("PomodoroStop", function() Pomodoro:stop() end, command_opts)
+	local command_opts = { bang = false, bar = false, complete = nil }
+	vim.api.nvim_create_user_command("PomodoroStart", function()
+		Pomodoro:start()
+	end, command_opts)
+	vim.api.nvim_create_user_command("PomodoroStatus", function()
+		Pomodoro:status()
+	end, command_opts)
+	vim.api.nvim_create_user_command("PomodoroStop", function()
+		Pomodoro:stop()
+	end, command_opts)
 end
 
 function Pomodoro.setup(opts)
-  opts = opts or {}
-  vim.tbl_deep_extend("force", Pomodoro.opts, opts)
-  setup_commands()
+	opts = opts or {}
+	Pomodoro.opts = vim.tbl_deep_extend("force", Pomodoro.opts, opts)
+	setup_commands()
 end
 
 return Pomodoro

--- a/lua/pomodoro/config.lua
+++ b/lua/pomodoro/config.lua
@@ -4,35 +4,35 @@
 ---@field time_break_long integer
 ---@field timers_to_long_break integer
 local opts = {
-  time_work = 25,
-  time_break_short = 5,
-  time_break_long = 20,
-  timers_to_long_break = 4,
-  icons = {
-    stopped = "󰚭",
-    started = "󰔟",
-    breaking = "󰞌",
-  },
-  ui = {
-    border = {
-      style = "rounded",
-      text = {
-        top_align = "left",
-      },
-      padding = { 1, 3 },
+    time_work = 25,
+    time_break_short = 5,
+    time_break_long = 20,
+    timers_to_long_break = 4,
+    icons = {
+        stopped = "󰚭",
+        started = "󰔟",
+        breaking = "󰞌",
     },
-    position = "50%",
-    size = {
-      width = "25%",
+    ui = {
+        border = {
+            style = "rounded",
+            text = {
+                top_align = "left",
+            },
+            padding = { 1, 3 },
+        },
+        position = "50%",
+        size = {
+            width = "25%",
+        },
+        opacity = 1,
     },
-    opacity = 1,
-  },
-  keymap = {
-    focus_next = { "j", "<Down>", "<Tab>" },
-    focus_prev = { "k", "<Up>", "<S-Tab>" },
-    close = { "<Esc>", "<C-c>" },
-    submit = { "<CR>", "<Space>" },
-  }
+    keymap = {
+        focus_next = { "j", "<Down>", "<Tab>" },
+        focus_prev = { "k", "<Up>", "<S-Tab>" },
+        close = { "<Esc>", "<C-c>" },
+        submit = { "<CR>", "<Space>" },
+    },
 }
 
 return opts

--- a/lua/pomodoro/ui.lua
+++ b/lua/pomodoro/ui.lua
@@ -5,10 +5,10 @@ local ui = {}
 
 ---@param pomodoro Pomodoro
 function ui.pomodoro_completed_menu(pomodoro)
-  local popup_options = pomodoro.opts.ui
-  if not pomodoro.opt.ui.border.text.top then
-    pomodoro.opt.ui.border.text.top = "[Pomodoro Completed]"
-  end
+	local popup_options = pomodoro.opts.ui
+	if not pomodoro.opts.ui.border.text.top then
+		pomodoro.opts.ui.border.text.top = "[Pomodoro Completed]"
+	end
 
   local menu_options = {
     keymap = pomodoro.opts.keymap,
@@ -40,11 +40,10 @@ end
 
 ---@param pomodoro Pomodoro
 function ui.break_completed_menu(pomodoro)
-  local popup_options = pomodoro.opts.ui
-  if not pomodoro.opt.ui.border.text.top then
-    pomodoro.opt.ui.border.text.top = "[Break Completed]"
-  end
-
+	local popup_options = pomodoro.opts.ui
+	if not pomodoro.opts.ui.border.text.top then
+		pomodoro.opts.ui.border.text.top = "[Break Completed]"
+	end
 
   local menu_options = {
     keymap = pomodoro.opts.keymap,

--- a/lua/pomodoro/ui.lua
+++ b/lua/pomodoro/ui.lua
@@ -1,5 +1,4 @@
-local Menu = require('nui.menu')
-local event = require('nui.utils.autocmd').event
+local Menu = require("nui.menu")
 
 local ui = {}
 
@@ -29,14 +28,17 @@ function ui.pomodoro_completed_menu(pomodoro)
 	-- NOTE: This was removed because it was executing even when an item was chosen
 	-- or mapped key was pressed
 	-- menu:on(event.BufLeave, function()
+	-- 	print("You left:")
 	-- 	pomodoro:stop()
 	-- 	menu:unmount()
 	-- end, { once = true })
 	menu:map("n", "b", function()
+		print("Break:")
 		pomodoro:start_break()
 		menu:unmount()
 	end, { noremap = true })
 	menu:map("n", "q", function()
+		print("Stop:")
 		pomodoro:stop()
 		menu:unmount()
 	end, { noremap = true })
@@ -49,18 +51,20 @@ function ui.break_completed_menu(pomodoro)
 		pomodoro.opts.ui.border.text.top = "[Break Completed]"
 	end
 
-  local menu_options = {
-    keymap = pomodoro.opts.keymap,
-    lines = { Menu.item('Start pomodoro'), Menu.item('Quit') },
-    on_close = function () pomodoro:stop() end,
-    on_submit = function(item)
-      if item.text == 'Quit' then
-        pomodoro:stop()
-      else
-        pomodoro:start_pomodoro()
-      end
-    end
-  }
+	local menu_options = {
+		keymap = pomodoro.opts.keymap,
+		lines = { Menu.item("Start pomodoro"), Menu.item("Quit") },
+		on_close = function()
+			pomodoro:stop()
+		end,
+		on_submit = function(item)
+			if item.text == "Quit" then
+				pomodoro:stop()
+			else
+				pomodoro:start_pomodoro()
+			end
+		end,
+	}
 
 	local menu = Menu(popup_options, menu_options)
 	menu:mount()

--- a/lua/pomodoro/ui.lua
+++ b/lua/pomodoro/ui.lua
@@ -4,84 +4,84 @@ local ui = {}
 
 ---@param pomodoro Pomodoro
 function ui.pomodoro_completed_menu(pomodoro)
-	local popup_options = pomodoro.opts.ui
-	if not pomodoro.opts.ui.border.text.top then
-		pomodoro.opts.ui.border.text.top = "[Pomodoro Completed]"
-	end
+    local popup_options = pomodoro.opts.ui
+    if not pomodoro.opts.ui.border.text.top then
+        pomodoro.opts.ui.border.text.top = "[Pomodoro Completed]"
+    end
 
-	local menu_options = {
-		keymap = pomodoro.opts.keymap,
-		lines = { Menu.item("Take break"), Menu.item("Quit") },
-		on_close = function()
-			pomodoro:stop()
-		end,
-		on_submit = function(item)
-			if item.text == "Quit" then
-				pomodoro:stop()
-			else
-				pomodoro:start_break()
-			end
-		end,
-	}
-	local menu = Menu(popup_options, menu_options)
-	menu:mount()
-	-- NOTE: This was removed because it was executing even when an item was chosen
-	-- or mapped key was pressed
-	-- menu:on(event.BufLeave, function()
-	-- 	print("You left:")
-	-- 	pomodoro:stop()
-	-- 	menu:unmount()
-	-- end, { once = true })
-	menu:map("n", "b", function()
-		print("Break:")
-		pomodoro:start_break()
-		menu:unmount()
-	end, { noremap = true })
-	menu:map("n", "q", function()
-		print("Stop:")
-		pomodoro:stop()
-		menu:unmount()
-	end, { noremap = true })
+    local menu_options = {
+        keymap = pomodoro.opts.keymap,
+        lines = { Menu.item("Take break"), Menu.item("Quit") },
+        on_close = function()
+            pomodoro:stop()
+        end,
+        on_submit = function(item)
+            if item.text == "Quit" then
+                pomodoro:stop()
+            else
+                pomodoro:start_break()
+            end
+        end,
+    }
+    local menu = Menu(popup_options, menu_options)
+    menu:mount()
+    -- NOTE: This was removed because it was executing even when an item was chosen
+    -- or mapped key was pressed
+    -- menu:on(event.BufLeave, function()
+    -- 	print("You left:")
+    -- 	pomodoro:stop()
+    -- 	menu:unmount()
+    -- end, { once = true })
+    menu:map("n", "b", function()
+        print("Break:")
+        pomodoro:start_break()
+        menu:unmount()
+    end, { noremap = true })
+    menu:map("n", "q", function()
+        print("Stop:")
+        pomodoro:stop()
+        menu:unmount()
+    end, { noremap = true })
 end
 
 ---@param pomodoro Pomodoro
 function ui.break_completed_menu(pomodoro)
-	local popup_options = pomodoro.opts.ui
-	if not pomodoro.opts.ui.border.text.top then
-		pomodoro.opts.ui.border.text.top = "[Break Completed]"
-	end
+    local popup_options = pomodoro.opts.ui
+    if not pomodoro.opts.ui.border.text.top then
+        pomodoro.opts.ui.border.text.top = "[Break Completed]"
+    end
 
-	local menu_options = {
-		keymap = pomodoro.opts.keymap,
-		lines = { Menu.item("Start pomodoro"), Menu.item("Quit") },
-		on_close = function()
-			pomodoro:stop()
-		end,
-		on_submit = function(item)
-			if item.text == "Quit" then
-				pomodoro:stop()
-			else
-				pomodoro:start_pomodoro()
-			end
-		end,
-	}
+    local menu_options = {
+        keymap = pomodoro.opts.keymap,
+        lines = { Menu.item("Start pomodoro"), Menu.item("Quit") },
+        on_close = function()
+            pomodoro:stop()
+        end,
+        on_submit = function(item)
+            if item.text == "Quit" then
+                pomodoro:stop()
+            else
+                pomodoro:start_pomodoro()
+            end
+        end,
+    }
 
-	local menu = Menu(popup_options, menu_options)
-	menu:mount()
-	-- NOTE: This was removed because it was executing even when an item was chosen
-	-- or mapped key was pressed
-	-- menu:on(event.BufLeave, function()
-	-- 	pomodoro:stop()
-	-- 	menu:unmount()
-	-- end, { once = true })
-	menu:map("n", "p", function()
-		pomodoro:start_pomodoro()
-		menu:unmount()
-	end, { noremap = true })
-	menu:map("n", "q", function()
-		pomodoro:stop()
-		menu:unmount()
-	end, { noremap = true })
+    local menu = Menu(popup_options, menu_options)
+    menu:mount()
+    -- NOTE: This was removed because it was executing even when an item was chosen
+    -- or mapped key was pressed
+    -- menu:on(event.BufLeave, function()
+    -- 	pomodoro:stop()
+    -- 	menu:unmount()
+    -- end, { once = true })
+    menu:map("n", "p", function()
+        pomodoro:start_pomodoro()
+        menu:unmount()
+    end, { noremap = true })
+    menu:map("n", "q", function()
+        pomodoro:stop()
+        menu:unmount()
+    end, { noremap = true })
 end
 
 return ui

--- a/lua/pomodoro/ui.lua
+++ b/lua/pomodoro/ui.lua
@@ -10,32 +10,36 @@ function ui.pomodoro_completed_menu(pomodoro)
 		pomodoro.opts.ui.border.text.top = "[Pomodoro Completed]"
 	end
 
-  local menu_options = {
-    keymap = pomodoro.opts.keymap,
-    lines = { Menu.item('Take break'), Menu.item('Quit') },
-    on_close = function () pomodoro:stop() end,
-    on_submit = function(item)
-      if item.text == 'Quit' then
-        pomodoro:stop()
-      else
-        pomodoro:start_break()
-      end
-    end
-  }
-  local menu = Menu(popup_options, menu_options)
-  menu:mount()
-  menu:on(event.BufLeave, function()
-    pomodoro:stop()
-    menu:unmount()
-  end, { once = true })
-  menu:map('n', 'b', function()
-    pomodoro:start_break()
-    menu:unmount()
-  end, { noremap = true })
-  menu:map('n', 'q', function()
-    pomodoro:stop()
-    menu:unmount()
-  end, { noremap = true })
+	local menu_options = {
+		keymap = pomodoro.opts.keymap,
+		lines = { Menu.item("Take break"), Menu.item("Quit") },
+		on_close = function()
+			pomodoro:stop()
+		end,
+		on_submit = function(item)
+			if item.text == "Quit" then
+				pomodoro:stop()
+			else
+				pomodoro:start_break()
+			end
+		end,
+	}
+	local menu = Menu(popup_options, menu_options)
+	menu:mount()
+	-- NOTE: This was removed because it was executing even when an item was chosen
+	-- or mapped key was pressed
+	-- menu:on(event.BufLeave, function()
+	-- 	pomodoro:stop()
+	-- 	menu:unmount()
+	-- end, { once = true })
+	menu:map("n", "b", function()
+		pomodoro:start_break()
+		menu:unmount()
+	end, { noremap = true })
+	menu:map("n", "q", function()
+		pomodoro:stop()
+		menu:unmount()
+	end, { noremap = true })
 end
 
 ---@param pomodoro Pomodoro
@@ -58,20 +62,22 @@ function ui.break_completed_menu(pomodoro)
     end
   }
 
-  local menu = Menu(popup_options, menu_options)
-  menu:mount()
-  menu:on(event.BufLeave, function()
-    pomodoro:stop()
-    menu:unmount()
-  end, { once = true })
-  menu:map('n', 'p', function()
-    pomodoro:start_pomodoro()
-    menu:unmount()
-  end, { noremap = true })
-  menu:map('n', 'q', function()
-    pomodoro:stop()
-    menu:unmount()
-  end, { noremap = true })
+	local menu = Menu(popup_options, menu_options)
+	menu:mount()
+	-- NOTE: This was removed because it was executing even when an item was chosen
+	-- or mapped key was pressed
+	-- menu:on(event.BufLeave, function()
+	-- 	pomodoro:stop()
+	-- 	menu:unmount()
+	-- end, { once = true })
+	menu:map("n", "p", function()
+		pomodoro:start_pomodoro()
+		menu:unmount()
+	end, { noremap = true })
+	menu:map("n", "q", function()
+		pomodoro:stop()
+		menu:unmount()
+	end, { noremap = true })
 end
 
 return ui


### PR DESCRIPTION
### Link to Issue:
N/A

### Description of Issue:
* Options are not picked up by the plugin
* Long breaks do not occur at the correct interval
* Timer rolls over to 1hr after second pomodoro

### Solution
This change will set the options back to the class during the setup function. 
Long breaks option is used in the if statement to ensure we are long breaking at the correct interval.
Removing the BufLeave event listener on the menu removes the case where we stop the timer that should be running. This allows the timers to function as they should.

### Features:
This also includes rewritten code from [orumin/pomodoro.nvim](https://github.com/orumin/pomodoro.nvim). Having the class typed was one motivation but the other was the ability to have the symbols configurable.

### Notes:
This changeset incorporates:

https://github.com/wthollingsworth/pomodoro.nvim/pull/10 for time formatting



